### PR TITLE
Force Production on Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "prebuild": "npm run clean",
-    "build": "bundle exec jekyll build",
+    "build": "JEKYLL_ENV=production bundle exec jekyll build",
     "clean": "rimraf _site && rimraf dist",
     "lint": "npm run lint:js --scripts-prepend-node-path; npm run lint:css --scripts-prepend-node-path",
     "lint:eslint": "eslint './_assets/javascript/**/*' ",


### PR DESCRIPTION
Only recently ran into this myself, but the `build` command was not setting the environment to `production`. If you were using `{{ jekyll.environment }}` or `{{ site.url }}` anywhere in a site, you might have been getting weird results. 🤦🏻‍♂️